### PR TITLE
Add support for creating a coffeescript sql loader

### DIFF
--- a/api.js
+++ b/api.js
@@ -431,7 +431,9 @@ function executeCreate() {
     }
 
     var templateType = Migration.TemplateType.DEFAULT_JS;
-    if (shouldCreateSqlFiles()) {
+    if (shouldCreateSqlFiles() && shouldCreateCoffeeFile()) {
+      templateType = Migration.TemplateType.COFFEE_SQL_FILE_LOADER;
+    } else if (shouldCreateSqlFiles()) {
       templateType = Migration.TemplateType.SQL_FILE_LOADER;
     } else if (shouldCreateCoffeeFile()) {
       templateType = Migration.TemplateType.DEFAULT_COFFEE;

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -137,11 +137,46 @@ Migration.prototype.sqlFileLoaderTemplate = function() {
   ].join("\n");
 };
 
+Migration.prototype.coffeeSqlFileLoaderTemplate = function() {
+  return [
+    "dbm = undefined",
+    "type = undefined",
+    "fs = require 'fs'",
+    "path = require 'path'",
+    "",
+    "#",
+    "# We receive the dbmigrate dependency from dbmigrate initially.",
+    "# This enables us to not have to rely on NODE_PATH.",
+    "#",
+    "exports.setup = (options) ->",
+    "  dbm = options.dbmigrate",
+    "  type = dbm.dataType",
+    "",
+    "",
+    "exports.up = (db, callback) ->",
+    "  filePath = path.join \"#{__dirname}/sqls/"+this.name.replace('.coffee', '')+"-up.sql\"",
+    "  fs.readFile filePath, {encoding: 'utf-8'}, (err,data) ->",
+    "    return callback err if err",
+    "",
+    "    db.runSql data, callback",
+    "",
+    "exports.down = (db, callback) ->",
+    "  filePath = path.join \"#{__dirname}/sqls/"+this.name.replace('.coffee', '')+"-down.sql\"",
+
+    "  fs.readFile filePath, {encoding: 'utf-8'}, (err,data) ->",
+    "    return callback err if err",
+    "",
+    "    db.runSql data, callback",
+    ""
+  ].join("\n");
+};
+
 Migration.TemplateType = {
   DEFAULT_JS: 0,
   DEFAULT_SQL: 1,
   SQL_FILE_LOADER: 2,
-  DEFAULT_COFFEE: 3
+  DEFAULT_COFFEE: 3,
+  COFFEE_SQL_FILE_LOADER: 4
 };
 
 Migration.prototype.getTemplate = function() {
@@ -152,6 +187,8 @@ Migration.prototype.getTemplate = function() {
       return this.sqlFileLoaderTemplate();
     case Migration.TemplateType.DEFAULT_COFFEE:
       return this.defaultCoffeeTemplate();
+    case Migration.TemplateType.COFFEE_SQL_FILE_LOADER:
+      return this.coffeeSqlFileLoaderTemplate();
     case Migration.TemplateType.DEFAULT_JS:
     default:
       return this.defaultJsTemplate();

--- a/test/migration_test.js
+++ b/test/migration_test.js
@@ -123,6 +123,16 @@ vows.describe('migration').addBatch({
           assert.equal(actual, migration.defaultCoffeeTemplate());
         }
       },
+      'as coffee sql loader' : {
+        topic: function() {
+            var migration = new Migration(fileName, dirName, date, Migration.TemplateType.COFFEE_SQL_FILE_LOADER, internals);
+            return migration;
+          },
+        'should return default coffee template': function(migration) {
+          var actual = migration.getTemplate();
+          assert.equal(actual, migration.coffeeSqlFileLoaderTemplate());
+        }
+      },
       'as default javascript' : {
         topic: function() {
             var migration = new Migration(fileName, dirName, date, Migration.TemplateType.DEFAULT_JS, internals);


### PR DESCRIPTION
@TabDigital/ping-api 

This will allow us to do sql migrations with a coffee file loader
There is a PR into the main repo at https://github.com/db-migrate/node-db-migrate/pull/271
But until that is merged we can use this
